### PR TITLE
kvify now expands into a map-literal.

### DIFF
--- a/src/clojure/jry.clj
+++ b/src/clojure/jry.clj
@@ -95,4 +95,6 @@
                                 m))))
 
 (defmacro kvify [& xs]
-  `(hash-map ~@(interleave (map keyword xs) xs)))
+  (if (apply distinct? xs)
+    (zipmap (map keyword xs) xs)
+    (throw (RuntimeException. (str "duplicate keys to kvify: " xs)))))

--- a/test/expectations/jry_expectations.clj
+++ b/test/expectations/jry_expectations.clj
@@ -62,5 +62,6 @@
 (expect false ((k= :one 1 :two 2 :thr 3) {:one 1 :two 1 :thr 3 :x "x"}))
 (expect false ((k= :one 1 :two 2 :thr 3) {:one 1 :two 2 :thr 1 :x "x"}))
 
-(expect '(clojure.core/hash-map :a a :b b)
+(expect '{:a a :b b}
   (expanding (kvify a b)))
+(expect RuntimeException (macroexpand-1 '(jry/kvify a a a a)))


### PR DESCRIPTION
Will now return PersistentHashMap or PersistentArrayMap as appropriate. 

Map-literals are emitted as calls to more efficient methods than clojure.core/hash-map or clojure.core/array-map.
