### PR TITLE
Upgrade to Clojure 1.11.1, generalize xor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :jar-name "jry.jar"
   :source-paths ["src/clojure"]
   :test-paths ["test"]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]]
   :deploy-repositories [["releases" :clojars]]
   :profiles {:dev {:dependencies [[expectations "1.4.36"]]}}
   :plugins [[lein-expectations "0.0.7"]

--- a/src/clojure/jry.clj
+++ b/src/clojure/jry.clj
@@ -1,8 +1,12 @@
 (ns jry
   (:require clojure.data))
 
-(defn xor [a b]
-  (and (or a b) (not (and a b))))
+(defn xor
+  [x y]
+  (if (and x (not y))
+    x
+    (when (and y (not x))
+      y)))
 
 (defn every [pred l]
   (when (every? pred l)
@@ -64,12 +68,6 @@
     {}
     (nth-vals* [] i m)))
 
-(defn update-vals [m f & args]
-  (reduce (fn [r [k v]] (assoc r k (apply f v args))) {} m))
-
-(defn update-keys [m f & args]
-  (reduce (fn [r [k v]] (assoc r (apply f k args) v)) {} m))
-
 (defn replace-vals [m replacements]
   (reduce
    (fn [r [k v]]
@@ -77,9 +75,6 @@
        (assoc r k v)
        r))
    m replacements))
-
-(def parse-double #(Double/parseDouble %))
-(def parse-long #(Long/parseLong %))
 
 (defn one? [x] (= 1 x))
 (defn two? [x] (= 2 x))

--- a/test/expectations/jry_expectations.clj
+++ b/test/expectations/jry_expectations.clj
@@ -4,10 +4,11 @@
 (expect one? 1)
 (expect two? 2)
 
-(expect false (xor false false))
+(expect nil (xor false false))
 (expect true (xor false true))
 (expect true (xor true false))
-(expect false (xor true true))
+(expect nil (xor true true))
+(expect :yes (reduce xor [nil :yes false]))
 
 (expect [1 2 3] (every identity [1 2 3]))
 (expect nil (every identity [1 2 nil]))
@@ -31,23 +32,13 @@
 (expect {} (flatten-keys {}))
 (expect {} (flatten-keys nil))
 
-(expect {:b {:e :f} :h {:e :f}}
-  (update-vals {:b {:c :d :e :f} :h {:c :d :e :f}} dissoc :c))
-
-(expect {1 :a 2 :b}
-        (update-keys {2 :a 3 :b} - 1))
-
 (expect [3 6]
-  (nth-vals 2 {1 {2 3} 4 {5 6}}))
+  (sort (nth-vals 2 {1 {2 3} 4 {5 6}})))
 
-(expect [3 {6 7} :a]
-  (nth-vals 2 {:a :a 1 {2 3} 4 {5 {6 7}}}))
+(expect #{3 {6 7} :a}
+  (set (nth-vals 2 {:a :a 1 {2 3} 4 {5 {6 7}}})))
 
 (expect {:a 1 :b 3} (replace-vals {:a 1 :b 2} {:b 3 :c 4}))
-
-(expect 10 (parse-long "10"))
-
-(expect 2.1 (parse-double "2.1"))
 
 (expect {:x "x", :one 1} ((k= :one 1) {:one 1 :x "x"}))
 (expect {"a" "aye!"} ((k= "a" "aye!") {"a" "aye!"}))


### PR DESCRIPTION
- Upgrades to Clojure 1.11.1, which includes `parse-double`, `parse-long`, `update-keys`, and `update-vals`. I removed those previously provided, which removes `WARNING`s from Clojure.
    [Clojure's `parse-*` functions](https://github.com/clojure/clojure/blob/4090f405466ea90bbaf3addbe41f0a6acb164dbb/src/clj/clojure/core.clj#L8102-L8124) differ slightly in their error handling.
- Generalizes `xor`
    Previously, `xor` always returned either `true` or `false`. With this change, `xor` now returns the non-nil, non-false argument, if one was provided. Otherwise, it returns `nil` instead of `false`. This improves the usage experience the same way `clojure.core/or` does by returning the first truthy argument instead of `true`, as the user can bind the result instead of separately and conditionally binding a result.

I consider both of these breaking but defer to you on picking a version number. If you'd like them split up, or if you'd prefer the Clojure upgrade was done in a backward-compatible way[^1], or something else, just let me know :smile: 

[^1]: I think this is best achieved by dispatching on `clojure.core/*clojure-version*` at the top level, around the offending `defn`s.